### PR TITLE
Accurics url refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,13 @@ ARG CLI_VERSION=1.0.49
 #  chmod 711 /entrypoint.sh /usr/bin/accurics
 
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
-  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /tmp/accurics.tar.gz && \
-  tar -xzvf /tmp/accurics.tar.gz -C /usr/bin/ && \
-  chmod 711 /entrypoint.sh /usr/bin/accurics && \
-  rm /tmp/accurics.tar.gz
+  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o accurics.tar.gz && \
+   tar xvfz accurics.tar.gz && \
+   rm -f accurics.tar.gz && \
+   mv accurics /usr/bin/ && \
+   chmod +x accurics && \
+   accurics version
 
-  
 RUN curl --location https://github.com/accurics/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz -o terrascan.tar.gz && \
     tar xvfz terrascan.tar.gz && \
     rm -f terrascan.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,12 @@ ARG CLI_VERSION=1.0.49
 #  chmod 711 /entrypoint.sh /usr/bin/accurics
 
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
-  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o accurics.tar.gz && \
-   tar xvfz accurics.tar.gz && \
-   rm -f accurics.tar.gz && \
-   mv accurics /usr/bin/ && \
-   chmod +x accurics && \
-   accurics version
+  curl --location https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o accurics.tar.gz && \
+  tar xvfz accurics.tar.gz && \
+  rm -f accurics.tar.gz && \
+  mv accurics /usr/bin/ && \
+  chmod +x /usr/bin/accurics && \
+  accurics version
 
 RUN curl --location https://github.com/accurics/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz -o terrascan.tar.gz && \
     tar xvfz terrascan.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ FROM alpine:3.13
 COPY entrypoint.sh /entrypoint.sh
 
 ARG TERRASCAN_VERSION=1.15.0
-ARG CLI_VERSION=1.0.37
+ARG CLI_VERSION=1.0.49
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
-  curl -s https://downloads.accurics.com/cli/dev/${CLI_VERSION}/accurics_linux -o /usr/bin/accurics && \
+  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /usr/bin/accurics && \  
   chmod 755 /entrypoint.sh /usr/bin/accurics
   
 RUN curl --location https://github.com/accurics/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz -o terrascan.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,16 @@ COPY entrypoint.sh /entrypoint.sh
 
 ARG TERRASCAN_VERSION=1.15.2
 ARG CLI_VERSION=1.0.49
+#RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
+#  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /usr/bin/accurics && \  
+#  chmod 711 /entrypoint.sh /usr/bin/accurics
+
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
-  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /usr/bin/accurics && \  
-  chmod 755 /entrypoint.sh /usr/bin/accurics
+  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /tmp/accurics.tar.gz && \
+  tar -xzvf /tmp/accurics.tar.gz -C /usr/bin/ && \
+  chmod 711 /entrypoint.sh /usr/bin/accurics && \
+  rm /tmp/accurics.tar.gz
+
   
 RUN curl --location https://github.com/accurics/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz -o terrascan.tar.gz && \
     tar xvfz terrascan.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ COPY entrypoint.sh /entrypoint.sh
 
 ARG TERRASCAN_VERSION=1.15.2
 ARG CLI_VERSION=1.0.49
-#RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
-#  curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /usr/bin/accurics && \  
-#  chmod 711 /entrypoint.sh /usr/bin/accurics
 
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
   curl --location https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o accurics.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.13
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 
-ARG TERRASCAN_VERSION=1.15.0
+ARG TERRASCAN_VERSION=1.15.2
 ARG CLI_VERSION=1.0.49
 RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
   curl -s https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_${CLI_VERSION}_linux_x86_64.tar.gz -o /usr/bin/accurics && \  
@@ -15,6 +15,7 @@ RUN curl --location https://github.com/accurics/terrascan/releases/download/v${T
     rm -f terrascan.tar.gz && \
     mv terrascan /usr/bin/ && \
     terrascan version
+
 # Github clone by ssh compatibility    
 RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk update && apk add --upgrade --no-cache ca-certificates curl jq git && \
   tar xvfz accurics.tar.gz && \
   rm -f accurics.tar.gz && \
   mv accurics /usr/bin/ && \
-  chmod +x /usr/bin/accurics && \
+  chmod +x /usr/bin/accurics entrypoint.sh && \
   accurics version
 
 RUN curl --location https://github.com/accurics/terrascan/releases/download/v${TERRASCAN_VERSION}/terrascan_${TERRASCAN_VERSION}_Linux_x86_64.tar.gz -o terrascan.tar.gz && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,7 +89,7 @@ run_accurics() {
      runMode="scan"
   else
      echo "running plan mode"
-     accurics init
+     #accurics init
   fi
   
    
@@ -112,6 +112,9 @@ run_accurics() {
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   #accurics tgplan
+  echo "processor"
+  cat /proc/cpuinfo
+
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,20 +98,7 @@ run_accurics() {
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
   fi
   
-  #echo "Details of running"
-  #echo "------------------"
-  #echo "INPUT_RUN_MOE="$INPUT_RUN_MODE 
-  #echo "params="$params 
-  #echo "plan_args="$plan_args 
-  #echo "pipeline_mode="$pipeline_mode
-  #echo "------------------"
   # Run accurics plan
-  #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
-  
-  #accurics tgplan
-  #echo "processor"
-  #cat /proc/cpuinfo
-
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,9 +106,9 @@ run_accurics() {
   echo "------------------"
   # Run accurics plan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
-  chmod +x /usr/bin/accurics
   
-  accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
+  accurics tgplan
+  #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,7 +106,9 @@ run_accurics() {
   echo "------------------"
   # Run accurics plan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
-  accurics plan $params $plan_args $pipeline_mode
+  chmod +x /usr/bin/accurics
+  cat /usr/bin/accurics
+  accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,6 +109,7 @@ run_accurics() {
   
   #accurics tgplan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
+  ls /usr/bin/
   
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,17 +97,17 @@ run_accurics() {
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
   fi
   
-  echo "Details of running"
-  echo "------------------"
-  echo "INPUT_RUN_MOE="$INPUT_RUN_MODE 
-  echo "params="$params 
-  echo "plan_args="$plan_args 
-  echo "pipeline_mode="$pipeline_mode
-  echo "------------------"
+  #echo "Details of running"
+  #echo "------------------"
+  #echo "INPUT_RUN_MOE="$INPUT_RUN_MODE 
+  #echo "params="$params 
+  #echo "plan_args="$plan_args 
+  #echo "pipeline_mode="$pipeline_mode
+  #echo "------------------"
   # Run accurics plan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
-  accurics tgplan
+  #accurics tgplan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,6 +74,10 @@ install_terraform() {
 run_accurics() {
   local params=$1
   local plan_args=$2
+  
+  chmod +x /usr/bin/accurics
+
+
   touch config
   terrascan version
   
@@ -109,8 +113,6 @@ run_accurics() {
   
   #accurics tgplan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
-  ls /usr/bin/
-  
   ACCURICS_PLAN_ERR=$?
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,7 +105,8 @@ run_accurics() {
   echo "pipeline_mode="$pipeline_mode
   echo "------------------"
   # Run accurics plan
-  accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
+  #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
+  accurics $INPUT_RUN_MODE "" "" $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,7 +76,7 @@ run_accurics() {
   local plan_args=$2
   
   chmod +x /usr/bin/accurics
-
+  accurics -h
 
   touch config
   terrascan version
@@ -89,7 +89,7 @@ run_accurics() {
      runMode="scan"
   else
      echo "running plan mode"
-     #accurics init
+     accurics init
   fi
   
    
@@ -112,8 +112,8 @@ run_accurics() {
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   #accurics tgplan
-  echo "processor"
-  cat /proc/cpuinfo
+  #echo "processor"
+  #cat /proc/cpuinfo
 
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   ACCURICS_PLAN_ERR=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,7 +106,7 @@ run_accurics() {
   echo "------------------"
   # Run accurics plan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
-  accurics $INPUT_RUN_MODE "" "" $pipeline_mode
+  accurics plan $params $plan_args $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,9 +75,6 @@ run_accurics() {
   local params=$1
   local plan_args=$2
   
-  chmod +x /usr/bin/accurics
-  accurics -h
-
   touch config
   terrascan version
   
@@ -115,7 +112,7 @@ run_accurics() {
   #echo "processor"
   #cat /proc/cpuinfo
 
-  #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
+  accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   ACCURICS_PLAN_ERR=$?
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,6 +97,13 @@ run_accurics() {
      echo "INPUT_PIPELINE="$INPUT_PIPELINE
   fi
   
+  echo "Details of running"
+  echo "------------------"
+  echo "INPUT_RUN_MOE="$INPUT_RUN_MODE 
+  echo "params="$params 
+  echo "plan_args="$plan_args 
+  echo "pipeline_mode="$pipeline_mode
+  echo "------------------"
   # Run accurics plan
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,7 +107,7 @@ run_accurics() {
   # Run accurics plan
   #accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   chmod +x /usr/bin/accurics
-  cat /usr/bin/accurics
+  
   accurics $INPUT_RUN_MODE $params $plan_args $pipeline_mode
   
   ACCURICS_PLAN_ERR=$?


### PR DESCRIPTION
# Why 

We updated the new terrascan version and acurics version
- ARG TERRASCAN_VERSION=1.15.2
- ARG CLI_VERSION=1.0.49

We refactor the URL from accurics download to https://www.tenable.com/downloads/api/v2/pages/cloud-security/files/accurics-cli_latest_linux_x86_64.tar.gz 

We are making an unzip and moving to /usr/bin

